### PR TITLE
Add palette icon as favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,16 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <!-- Background -->
-  <rect width="32" height="32" rx="6" fill="#1E1E1E"/>
-
-  <!-- Design Token colors representing a token palette -->
-  <circle cx="10" cy="10" r="4" fill="#7C3AED"/>
-  <circle cx="22" cy="10" r="4" fill="#2563EB"/>
-  <circle cx="10" cy="22" r="4" fill="#10B981"/>
-  <circle cx="22" cy="22" r="4" fill="#F59E0B"/>
-
-  <!-- Center connector representing token management -->
-  <rect x="14" y="8" width="4" height="4" rx="1" fill="#E5E5E5"/>
-  <rect x="8" y="14" width="4" height="4" rx="1" fill="#E5E5E5"/>
-  <rect x="20" y="14" width="4" height="4" rx="1" fill="#E5E5E5"/>
-  <rect x="14" y="20" width="4" height="4" rx="1" fill="#E5E5E5"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3B82F6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="13.5" cy="6.5" r=".5" fill="#3B82F6"></circle>
+  <circle cx="17.5" cy="10.5" r=".5" fill="#3B82F6"></circle>
+  <circle cx="8.5" cy="7.5" r=".5" fill="#3B82F6"></circle>
+  <circle cx="6.5" cy="12.5" r=".5" fill="#3B82F6"></circle>
+  <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"></path>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,7 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#3B82F6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="13.5" cy="6.5" r=".5" fill="#3B82F6"></circle>
-  <circle cx="17.5" cy="10.5" r=".5" fill="#3B82F6"></circle>
-  <circle cx="8.5" cy="7.5" r=".5" fill="#3B82F6"></circle>
-  <circle cx="6.5" cy="12.5" r=".5" fill="#3B82F6"></circle>
-  <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"></path>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <style>
+    .icon { stroke: #3B82F6; fill: #3B82F6; }
+    .outline { stroke: #3B82F6; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .icon { stroke: #60A5FA; fill: #60A5FA; }
+      .outline { stroke: #60A5FA; }
+    }
+  </style>
+  <circle class="icon" cx="13.5" cy="6.5" r=".5"></circle>
+  <circle class="icon" cx="17.5" cy="10.5" r=".5"></circle>
+  <circle class="icon" cx="8.5" cy="7.5" r=".5"></circle>
+  <circle class="icon" cx="6.5" cy="12.5" r=".5"></circle>
+  <path class="outline" d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"></path>
 </svg>


### PR DESCRIPTION
Replace the previous token grid design with a Lucide palette icon in blue (#3B82F6) to better represent the design token manager theme.